### PR TITLE
Keep input delay and make it gradually worse

### DIFF
--- a/files/scripts/input_delay.lua
+++ b/files/scripts/input_delay.lua
@@ -1,0 +1,19 @@
+local input_delay = {}
+
+function input_delay.OnWorldPreUpdate()
+	local player = EntityGetWithTag("player_unit")[1] or EntityGetWithTag("polymorphed_player")[1]
+	if not player then return end
+
+	local controls_comp = EntityGetFirstComponentIncludingDisabled(player, "ControlsComponent")
+	if not controls_comp then return end
+
+	local amplitude = math.min(math.floor(GameGetFrameNum() / (60 * 60 * 2)), 31)
+	local middle = amplitude / 2
+	local wave = math.sin(GameGetFrameNum() / (60 * 60))
+	local delay = math.max(0, math.min(middle + math.sin(wave) * middle, 31))
+
+	ComponentSetValue2(controls_comp, "input_latency_frames", delay)
+
+end
+
+return input_delay

--- a/init.lua
+++ b/init.lua
@@ -1,7 +1,7 @@
 local fuckedupenemies = dofile("mods/noita.fairmod/files/scripts/fuckedupenemies.lua")
 local heartattack = dofile("mods/noita.fairmod/files/scripts/heartattack.lua")
 local nukes = dofile("mods/noita.fairmod/files/scripts/nukes/nukes.lua")
-
+local input_delay = dofile("mods/noita.fairmod/files/scripts/input_delay.lua")
 
 
 dofile_once("mods/noita.fairmod/files/scripts/coveryourselfinoil.lua")
@@ -18,12 +18,6 @@ function OnPlayerSpawned(player)
 	plays = plays + 1
 	ModSettingSet("fairmod.plays", plays)
 
-	local controls_comp = EntityGetFirstComponentIncludingDisabled(player, "ControlsComponent")
-	if controls_comp and Random(0, 5) == 1 then
-		local delay = Random(0, math.min(15, plays)) -- max 0.25 seconds
-		ComponentSetValue2(controls_comp, "input_latency_frames", delay)
-	end
-
 	heartattack.OnPlayerSpawned(player)
 	local x, y = EntityGetTransform(player)
 	local _, snail_x, snail_y = RaytracePlatforms(x - 100, y - 100, x - 100, y + 500)
@@ -35,6 +29,7 @@ ModRegisterAudioEventMappings("mods/noita.fairmod/GUIDs.txt")
 function OnWorldPreUpdate()
 	fuckedupenemies.OnWorldPreUpdate()
 	nukes.OnWorldPreUpdate();
+	input_delay.OnWorldPreUpdate()
 end
 
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c81388f0-b711-4221-b44f-8aa0bbcb3a55)

Input delay follows this graph I think. X axis is minutes in run and y axis is input delay. So it gets worse the longer the run goes on but varies during each minute