### PR TITLE
Fix clipboard message always the same

### DIFF
--- a/files/content/clipboard/init.lua
+++ b/files/content/clipboard/init.lua
@@ -12,7 +12,8 @@ local messages = {
 
 function clipboard.OnPlayerSpawned()
 	if imgui then
-		imgui.SetClipboardText(messages[math.random(#messages)])
+		SetRandomSeed(123, 456)
+		imgui.SetClipboardText(messages[Random(1, #messages)])
 	end
 end
 


### PR DESCRIPTION
I thought `math.random` came pre-seeded with a random value but that doesn't seem to be the case. So it was just putting the same message in the clipboard every time. Change it to `SetRandomSeed`+`Random` so it picks based on the world seed instead.