### PR TITLE
Tweaks and fixes to existing things

### DIFF
--- a/data/scripts/props/root_grower_fruit.lua
+++ b/data/scripts/props/root_grower_fruit.lua
@@ -3,14 +3,14 @@ local pos_x, pos_y = EntityGetTransform(GetUpdatedEntityID())
 local r = ProceduralRandomf(pos_x, pos_y + GameGetFrameNum())
 if r < 0.5 then
 	-- don't overlap fruits
-	for _, e in ipairs(EntityGetInRadiusWithTag(pos_x, pos_y, 15, "prop")) do
+	for _, e in ipairs(EntityGetInRadiusWithTag(pos_x, pos_y, 20, "prop")) do
 		if not EntityHasTag(e, "root") then return end
 	end
 
 	-- fruit
 	local e = EntityLoad("data/entities/props/root_grower_fruit.xml", pos_x, pos_y)
 	EntitySetTransform(e, pos_x, pos_y, ProceduralRandomf(pos_x, pos_y, -math.pi * 0.5, math.pi * 0.5))
-elseif r < 0.9 then
+elseif r < 0.8 then
 	local x = pos_x + ProceduralRandomf(pos_x - 7, pos_y, -3, 3)
 	local y = pos_y + ProceduralRandomf(pos_x, pos_y, -3, 3)
 	EntityLoad("data/entities/props/root_grower_branch.xml", x, y)

--- a/data/scripts/props/root_grower_split.lua
+++ b/data/scripts/props/root_grower_split.lua
@@ -2,7 +2,7 @@ local entity_id = GetUpdatedEntityID()
 local pos_x, pos_y = EntityGetTransform(entity_id)
 
 -- Anti-lag, since these things can multiply a lot we don't want to have too many in one spot
-for _, e in ipairs(EntityGetInRadiusWithTag(pos_x, pos_y, 15, "root")) do
+for _, e in ipairs(EntityGetInRadiusWithTag(pos_x, pos_y, 25, "root")) do
 	if e ~= entity_id then
 		EntityKill(entity_id)
 		return
@@ -17,7 +17,7 @@ if r < 0.1 then
 	pos_y = pos_y + ProceduralRandomf(pos_x, pos_y + 54, -3, 3)
 	EntityLoad("data/entities/props/root_grower.xml", pos_x, pos_y)
 	return
-elseif r < 0.9 then
+elseif r < 0.8 then
 	-- regular small branch
 	pos_x = pos_x + ProceduralRandomf(pos_x - 7, pos_y, -3, 3)
 	pos_y = pos_y + ProceduralRandomf(pos_x, pos_y, -3, 3)

--- a/files/content/better_props/init_modify_all_props.lua
+++ b/files/content/better_props/init_modify_all_props.lua
@@ -31,12 +31,34 @@ local function fixup_prop_children(element)
 	for comp in element:each_of("DamageModelComponent") do
 		comp:set("blood_multiplier", 3)
 		-- better chance to see things fly around instead of exploding immediately
-		elem_multiply_attr(comp, "hp", 2)
+		-- try not to modify enemy hp
+		if element:first_of("AnimalAIComponent") == nil then
+			if tonumber(comp:get("hp") or "1") < 1 then comp:set("hp", 1) end
+			elem_multiply_attr(comp, "hp", 2)
+		end
 	end
 
 	for comp in element:each_of("MaterialInventoryComponent") do
-		elem_multiply_attr(comp, "leak_pressure_min", 5)
-		elem_multiply_attr(comp, "leak_pressure_max", 5)
+		-- More sane defaults for components that don't have these set
+		-- Use normal defaults if it has b2_force_on_leak
+		if comp:get("b2_force_on_leak") ~= nil then
+			comp:apply_defaults({
+				MaterialInventoryComponent = {
+					leak_pressure_min = 0.7,
+					leak_pressure_max = 1.1,
+				}
+			})
+		else
+			comp:apply_defaults({
+				MaterialInventoryComponent = {
+					leak_pressure_min = 0.1,
+					leak_pressure_max = 0.25,
+					b2_force_on_leak = 0.2,
+				}
+			})
+		end
+		elem_multiply_attr(comp, "leak_pressure_min", 2)
+		elem_multiply_attr(comp, "leak_pressure_max", 6)
 		elem_multiply_attr(comp, "b2_force_on_leak", 5)
 		comp:set("on_death_spill", true)
 		comp:set("leak_on_damage_percent", 0.999)

--- a/files/content/better_props/init_wild_growth.lua
+++ b/files/content/better_props/init_wild_growth.lua
@@ -9,7 +9,7 @@ ModLuaFileAppend(
 local function rootgrower_apply_changes(element)
 	for comp in element:each_of("LifetimeComponent") do
 		-- Go longer
-		comp:set("lifetime", 500)
+		comp:set("lifetime", 350)
 	end
 
 	for comp in element:each_of("LuaComponent") do
@@ -27,7 +27,7 @@ local function rootgrower_apply_changes(element)
 
 	-- GIRTHY vines
 	for comp in element:each_of("ParticleEmitterComponent") do
-		comp:set("count_min", 20)
+		comp:set("count_min", 30)
 		comp:set("count_max", 140)
 	end
 end
@@ -37,12 +37,15 @@ for rootgrower_xml in nxml.edit_file("data/entities/props/root_grower.xml") do
 
 	local collision = rootgrower_xml:first_of("CollisionTriggerComponent")
 	if collision ~= nil then
-		collision:set("width", 350)
-		collision:set("height", 350)
-		collision:set("radius", 350)
+		collision:set("width", 300)
+		collision:set("height", 300)
+		collision:set("radius", 300)
 	end
 end
 
 for rootgrower_branch_xml in nxml.edit_file("data/entities/props/root_grower_branch.xml") do
 	rootgrower_apply_changes(rootgrower_branch_xml:first_of("Base"))
 end
+
+
+ModMaterialsFileAdd("mods/noita.fairmod/files/content/better_props/material_overrides.xml")

--- a/files/content/better_props/material_overrides.xml
+++ b/files/content/better_props/material_overrides.xml
@@ -1,0 +1,23 @@
+
+<Materials>
+	<CellDataChild
+		_parent="wood_static"
+		tags="[corrodible],[alchemy],[solid],[earth]"
+		_inherit_reactions="0"
+		name="root_growth"
+		ui_name="$mat_root"
+		durability="3"
+		wang_color="ff412D41"
+		hp="50"
+		burnable="0"
+		>
+		<Graphics
+			texture_file="data/materials_gfx/root_growth.png"
+			color="ff007540"/>
+	</CellDataChild>
+
+	<Reaction probability="80"
+		input_cell1="root_growth" input_cell2="[fire]"
+		output_cell1="air" output_cell2="[fire]"
+		/>
+</Materials>

--- a/files/content/better_props/temple_altar_right_append.lua
+++ b/files/content/better_props/temple_altar_right_append.lua
@@ -1,6 +1,6 @@
 local old_init = init
 init = function(x, y, w, h)
 	-- Underground jungle holy mountain
-	if y > 6000 and y < 7000 then EntityLoad("data/entities/props/root_grower.xml", x + 200, y + 550) end
+	if y > 6000 and y < 7000 then EntityLoad("data/entities/props/root_grower.xml", x + 190, y + 560) end
 	old_init(x, y, w, h)
 end

--- a/files/content/perk_tomfoolery/scripts/perk_append.lua
+++ b/files/content/perk_tomfoolery/scripts/perk_append.lua
@@ -3,7 +3,7 @@ local old_perk_spawn = perk_spawn
 perk_spawn = function(x, y, perk_id, dont_remove_other_perks_)
 	local perk = old_perk_spawn(x, y, perk_id, dont_remove_other_perks_)
 	SetRandomSeed(x, y)
-	local chance = 50
+	local chance = 10
 	if Random(1, 100) <= chance then
 		local perk_data = get_perk_with_id(perk_list, perk_id)
 		if perk_data == nil then

--- a/files/content/perk_tomfoolery/scripts/perk_tomfoolery.lua
+++ b/files/content/perk_tomfoolery/scripts/perk_tomfoolery.lua
@@ -51,6 +51,7 @@ if reveal_delay <= timer then
 	ComponentSetValue2(ui_info_component, "name", actual_perk_name)
 	ComponentSetValue2(item_component, "item_name", actual_perk_name)
 	ComponentSetValue2(item_component, "ui_description", actual_perk_desc)
+	EntityRefreshSprite(entity_id, sprite_component)
 end
 
 timer = timer + 1


### PR DESCRIPTION
- Perk tomfoolery updates the graphic immediately when changing to the real perk.
- Reduce chance of fake perks.
- Nerf vine growth.
- Make vines not catch fire, but make them easier to destroy.
- Don't multiply some enemy HPs in the props script.
- Re-enable launching all props with MaterialInventoryComponent, tweaked so it's not as crazy as before.