### PR TITLE
A few more fixes

### DIFF
--- a/files/content/gamblecore/scratch_ticket/ticket.lua
+++ b/files/content/gamblecore/scratch_ticket/ticket.lua
@@ -73,6 +73,8 @@ end
 function interacting(entity_who_interacted, entity_interacted, interactable_name)
 	-- If interacting with a dialog system, don't open scratch ticket at the same time
 	if dialog_system.is_any_dialog_open() or GameHasFlagRun("fairmod_dialog_interacting") then return end
+	if GameHasFlagRun("fairmod_interacted_with_anything_this_frame") then return end
+	GameAddFlagRun("fairmod_interacted_with_anything_this_frame")
 
 	if not EntityHasTag(entity_interacted, "viewing") then
 		EntityAddTag(entity_interacted, "viewing")

--- a/files/content/information_kiosk/information_hamis.lua
+++ b/files/content/information_kiosk/information_hamis.lua
@@ -84,7 +84,8 @@ remaining_tips = remaining_tips or {}
 function interacting(player, entity_interacted, interactable_name)
 	-- If viewing a scratch ticket, don't interact at the same time
 	if EntityHasTag(entity_interacted, "viewing") or GameHasFlagRun("fairmod_scratch_interacting") then return end
-
+	if GameHasFlagRun("fairmod_interacted_with_anything_this_frame") then return end
+	GameAddFlagRun("fairmod_interacted_with_anything_this_frame")
 	GameAddFlagRun("fairmod_dialog_interacting")
 
 	dialog = dialog_system.open_dialog({

--- a/files/content/loan_shark/loanshark.lua
+++ b/files/content/loan_shark/loanshark.lua
@@ -11,7 +11,8 @@ SetRandomSeed(x + GameGetFrameNum(), y)
 function interacting(entity_who_interacted, entity_interacted, interactable_name)
 	-- If viewing a scratch ticket, don't interact at the same time
 	if EntityHasTag(entity_interacted, "viewing") or GameHasFlagRun("fairmod_scratch_interacting") then return end
-
+	if GameHasFlagRun("fairmod_interacted_with_anything_this_frame") then return end
+	GameAddFlagRun("fairmod_interacted_with_anything_this_frame")
 	local loan_shark_debt = tonumber(GlobalsGetValue("loan_shark_debt", "0"))
 
 	GameAddFlagRun("fairmod_dialog_interacting")

--- a/files/content/loan_shark/loanshark.xml
+++ b/files/content/loan_shark/loanshark.xml
@@ -3,7 +3,7 @@
 		_tags="loanshark_sprite"
 		image_file="mods/noita.fairmod/files/content/loan_shark/loanshark_anim.xml"
 		rect_animation="idle"
-		z_index="2"
+		z_index="22"
 	/>
 
 	<SpriteAnimatorComponent
@@ -14,7 +14,7 @@
 		image_file="mods/noita.fairmod/files/content/loan_shark/desk.png"
 		offset_x="32"
 		offset_y="17"
-		z_index="1"
+		z_index="21"
 	/>
 
 

--- a/files/content/payphone/content/dialog.lua
+++ b/files/content/payphone/content/dialog.lua
@@ -3,7 +3,7 @@ local function get_distance(x1, y1, x2, y2)
 	return math.sqrt((x2 - x1) ^ 2 + (y2 - y1) ^ 2)
 end
 
-local function statue_check()
+local function statue_get_distance()
 	local player = (EntityGetWithTag("player_unit") or {})[1]
 	if player == nil then return true end
 	local x,y = EntityGetTransform(player)
@@ -12,14 +12,20 @@ local function statue_check()
 	if statue == nil then return true end
 	local x2,y2 = EntityGetTransform(statue)
 
-	local dist = get_distance(x, y, x2, y2)
+	return get_distance(x, y, x2, y2)
+end
+
+local function statue_check()
+	local statue = EntityGetClosestWithTag(x, y, "phonecall_statue")
+
+	local dist = statue_get_distance()
 	if dist < 25 then
 		local phys = EntityGetFirstComponent(statue, "PhysicsBody2Component")
 		local x, y, angle, vel_x, vel_y, angular_vel = PhysicsComponentGetTransform(phys)
 		PhysicsComponentSetTransform(phys, x, y, angle, vel_x + 20, vel_y - 1, -20)
 		return true
 	end
-	return dist > 500
+	return dist > 100
 end
 
 local function statue_closeness_dialog(dialog)
@@ -1522,6 +1528,9 @@ return {
 		text = [[Psst . . .
 		{@pause 60}
 		Come closer . . .]],
+		can_call = function() -- optional
+			return statue_get_distance() < 100
+		end,
 		options = {
 			{
 				text = "How's this?",

--- a/files/content/payphone/payphone.lua
+++ b/files/content/payphone/payphone.lua
@@ -113,6 +113,12 @@ local get_random_call = function()
 end
 
 function interacting(entity_who_interacted, entity_interacted, interactable_name)
+	-- If viewing a scratch ticket, don't interact at the same time
+	if EntityHasTag(entity_interacted, "viewing") or GameHasFlagRun("fairmod_scratch_interacting") then return end
+	if GameHasFlagRun("fairmod_interacted_with_anything_this_frame") then return end
+	GameAddFlagRun("fairmod_interacted_with_anything_this_frame")
+	GameAddFlagRun("fairmod_dialog_interacting")
+	
 	SetRandomSeed(x, y + GameGetFrameNum())
 	if ringing then
 		ringing = false
@@ -121,6 +127,9 @@ function interacting(entity_who_interacted, entity_interacted, interactable_name
 		GamePlaySound("mods/noita.fairmod/fairmod.bank", "payphone/pickup", x, y)
 		-- open random call
 		local call = get_random_call()
+		call.on_closed = function()
+			GameRemoveFlagRun("fairmod_dialog_interacting")
+		end
 		dialog_system.dialog_box_height = 70
 
 		dialog = dialog_system.open_dialog(call)
@@ -143,6 +152,9 @@ function interacting(entity_who_interacted, entity_interacted, interactable_name
 					end,
 				},
 			},
+			on_closed = function()
+				GameRemoveFlagRun("fairmod_dialog_interacting")
+			end,
 		})
 	end
 end

--- a/files/content/piss/player_immersion.lua
+++ b/files/content/piss/player_immersion.lua
@@ -16,6 +16,7 @@ local controls_comp = EntityGetFirstComponentIncludingDisabled(entity, "Controls
 local entity_x, entity_y, _, scale_x = EntityGetTransform(entity)
 
 last_ingestion_size = last_ingestion_size or nil
+last_notice_frame = last_notice_frame or 0
 
 local ingestion_comp = EntityGetFirstComponent(entity, "IngestionComponent")
 if ingestion_comp then
@@ -95,6 +96,12 @@ if ingestion_comp then
 
 			ingestion_size = ingestion_size - 15
 			ComponentSetValue2(ingestion_comp, "ingestion_size", ingestion_size)
+		end
+	elseif piss_button or shit_button then
+		local current_frame = GameGetFrameNum()
+		if current_frame - last_notice_frame > 60 then
+			last_notice_frame = current_frame
+			GamePrint("Stomach is empty!")
 		end
 	end
 

--- a/init.lua
+++ b/init.lua
@@ -240,6 +240,9 @@ ModRegisterAudioEventMappings("mods/noita.fairmod/GUIDs.txt")
 
 function OnWorldPreUpdate()
 	ModTextFileSetContent = SetContent
+
+	GameRemoveFlagRun("fairmod_interacted_with_anything_this_frame")
+
 	local frames = GameGetFrameNum()
 	if frames % 30 == 0 then
 		fuckedupenemies:OnWorldPreUpdate()


### PR DESCRIPTION
- Improve scratch ticket interact exclusion so it doesn't do two interactions at the same time as closing the ticket, and also excludes interacting with phone booth at the same time.
- Notification on empty stomach when trying to shit or piss.
- Fix loanprey Z order hiding the heart when it teleports away from you.
- Fix statue calls if it's too far away to still be on the phone.
