### PR TITLE
HM collapse improvements.

### DIFF
--- a/files/content/collapse/perk_pickup_append.lua
+++ b/files/content/collapse/perk_pickup_append.lua
@@ -1,14 +1,19 @@
 
-
 local old_item_pickup = item_pickup
 item_pickup = function(entity_item, entity_who_picked, item_name)
 	if entity_who_picked ~= nil then
-		local x,y = EntityGetTransform(entity_who_picked)
+		local x, y = EntityGetTransform(entity_item)
 
-		if ProceduralRandom(x + entity_item, y + GameGetFrameNum(), 1, 100) <= 2 then
-			GamePlaySound("data/audio/Desktop/misc.bank", "misc/temple_collapse", x, y - 40)
-			EntityLoad("data/entities/particles/image_emitters/magical_symbol.xml", x, y - 40)
-			EntityLoad("mods/noita.fairmod/files/content/collapse/screen_shaker.xml", x, y - 40)
+		local biome_filename = DebugBiomeMapGetFilename(x, y) or ""
+		local is_boss_arena = biome_filename:match("boss_arena") ~= nil
+		if biome_filename:match("temple_altar") ~= nil or is_boss_arena then
+			local x_offset = is_boss_arena and 2585 or 0
+
+			if ProceduralRandom(x + entity_item, y + GameGetFrameNum(), 1, 100) <= 2 then
+				GamePlaySound("data/audio/Desktop/misc.bank", "misc/temple_collapse", x_offset, y - 10)
+				EntityLoad("data/entities/particles/image_emitters/magical_symbol.xml", x_offset, y - 10)
+				EntityLoad("mods/noita.fairmod/files/content/collapse/screen_shaker.xml", x_offset, y - 10)
+			end
 		end
 	end
 	old_item_pickup(entity_item, entity_who_picked, item_name)

--- a/files/content/collapse/workshop_exit_child.lua
+++ b/files/content/collapse/workshop_exit_child.lua
@@ -1,0 +1,7 @@
+
+local old_GetUpdatedEntityID = GetUpdatedEntityID
+GetUpdatedEntityID = function()
+	return EntityGetParent(old_GetUpdatedEntityID())
+end
+
+dofile("data/scripts/buildings/workshop_exit.lua")


### PR DESCRIPTION
- Removed one collapser.
- Collapse faster.
- Collapse in bigger and fewer chunks.
- Increased curse area.
- Fixed collapse visuals being in the wrong location.
- Fixed perk collapse troll from working outside of HMs.
- Fixed collapse troll showing the visual in the wrong location.
- Make heart and refresh more inaccessible.