### PR TITLE
Labour of Hate day 1 small things

### DIFF
--- a/files/content/better_props/spidernest_append.lua
+++ b/files/content/better_props/spidernest_append.lua
@@ -22,3 +22,7 @@ if e_id ~= 0 then
 		ComponentSetValue2(comp, "mVelocity", (x - pos_x) * 100, (y - pos_y) * 100)
 	end
 end
+
+function SetValueInteger(...)
+	-- do nothing
+end

--- a/files/content/boss_arena_improvements/boss_arena_append.lua
+++ b/files/content/boss_arena_improvements/boss_arena_append.lua
@@ -1,0 +1,11 @@
+
+
+local old_spawn_boss_music_and_statues = spawn_boss_music_and_statues
+function spawn_boss_music_and_statues(x, y)
+	old_spawn_boss_music_and_statues(x, y)
+
+	SetRandomSeed(GameGetFrameNum(), 0)
+	if Random(1, 3) == 1 then
+		EntityLoad("mods/noita.fairmod/files/content/snowman/snowman.xml", x - 80, y)
+	end
+end

--- a/files/content/boss_arena_improvements/init.lua
+++ b/files/content/boss_arena_improvements/init.lua
@@ -1,0 +1,3 @@
+
+
+ModLuaFileAppend("data/scripts/biomes/boss_arena.lua", "mods/noita.fairmod/files/content/boss_arena_improvements/boss_arena_append.lua")

--- a/files/content/cheese_finish/convert_everything_to_cheese.lua
+++ b/files/content/cheese_finish/convert_everything_to_cheese.lua
@@ -1,0 +1,19 @@
+SetRandomSeed(GameGetFrameNum(), GameGetFrameNum() * 1337)
+
+local materials = CellFactory_GetAllSands()
+
+local cheese_solids = {}
+local cheese_powders = {}
+
+for _, mat in ipairs(materials) do
+	local mat_id = CellFactory_GetType(mat)
+	if CellFactory_HasTag(mat_id, "[cheese]") then
+		if CellFactory_HasTag(mat_id, "[static]") then
+			table.insert(cheese_solids, mat)
+		else
+			table.insert(cheese_powders, mat)
+		end
+	end
+end
+
+ConvertEverythingToGold(cheese_powders[Random(1, #cheese_powders)], cheese_solids[Random(1, #cheese_solids)])

--- a/files/content/cheese_finish/ending_sequence_prepend.lua
+++ b/files/content/cheese_finish/ending_sequence_prepend.lua
@@ -1,0 +1,15 @@
+
+local cheese_ending_replacements = {
+	["data/entities/animals/boss_centipede/ending/midas_walls.xml"] = true,
+	["data/entities/animals/boss_centipede/ending/midas.xml"] = true,
+	["data/entities/animals/boss_centipede/ending/midas_radioactive.xml"] = true,
+}
+
+local old_EntityLoad = EntityLoad
+function EntityLoad(filename, pos_x, pos_y)
+	if GameHasFlagRun("Epic_leet_hacker") and cheese_ending_replacements[filename] then
+		filename = "mods/noita.fairmod/files/content/cheese_finish/midas_cheese.xml"
+	end
+	return old_EntityLoad(filename, pos_x or 0, pos_y or 0)
+end
+

--- a/files/content/cheese_finish/init.lua
+++ b/files/content/cheese_finish/init.lua
@@ -1,0 +1,7 @@
+local original_ending_seq = ModTextFileGetContent("data/entities/animals/boss_centipede/ending/sampo_start_ending_sequence.lua")
+local ending_seq_prepends = ModTextFileGetContent("mods/noita.fairmod/files/content/cheese_finish/ending_sequence_prepend.lua")
+
+ModTextFileSetContent(
+	"data/entities/animals/boss_centipede/ending/sampo_start_ending_sequence.lua",
+	ending_seq_prepends .. original_ending_seq
+)

--- a/files/content/cheese_finish/midas_cheese.xml
+++ b/files/content/cheese_finish/midas_cheese.xml
@@ -1,0 +1,22 @@
+<Entity>
+	<InheritTransformComponent/>
+
+	<MagicConvertMaterialComponent
+		kill_when_finished="0"
+		from_any_material="1"
+		steps_per_frame="3"
+		to_material="cheese_static"
+		clean_stains="0"
+		is_circle="1"
+		radius="300" 
+		convert_same_material="0"
+	/>
+
+	<LifetimeComponent lifetime="160" />
+
+	<LuaComponent
+		execute_every_n_frame="159"
+		remove_after_executed="1"
+		script_source_file="mods/noita.fairmod/files/content/cheese_finish/convert_everything_to_cheese.lua" 
+	/>
+</Entity>

--- a/files/content/milk_biome/egg_hatch_append.lua
+++ b/files/content/milk_biome/egg_hatch_append.lua
@@ -1,0 +1,4 @@
+local entity_id = GetUpdatedEntityID()
+local x, y = EntityGetTransform( entity_id )
+
+GameCreateParticle("fairmod_egg_white", x, y, 30, 10, 10, false, true, true)

--- a/files/content/milk_biome/init.lua
+++ b/files/content/milk_biome/init.lua
@@ -61,6 +61,24 @@ for xml in nxml.edit_file("data/entities/items/pickup/potion_milk.xml") do
 end
 
 
+ModLuaFileAppend("data/scripts/items/egg_hatch.lua", "mods/noita.fairmod/files/content/milk_biome/egg_hatch_append.lua")
+
+for xml in nxml.edit_file("data/entities/items/pickup/egg_hollow.xml") do
+    xml:add_child(nxml.new_element("MaterialInventoryComponent", {
+        drop_as_item = 0,
+        on_death_spill = 1,
+        leak_on_damage_percent = 0.5,
+        leak_pressure_min = 0.2,
+        leak_pressure_max = 0.7,
+    }, {
+        nxml.new_element("count_per_material_type", {}, {
+            nxml.new_element("Material", { material = "fairmod_egg_white", count = 80 }),
+            nxml.new_element("Material", { material = "fairmod_egg_yolk", count = 60 }),
+        })
+    }))
+end
+
+
 function milk.OnMagicNumbersAndWorldSeedInitialized()
     --Conga: This commented out code inserts the milk biome on the right side of the vault
     for content in nxml.edit_file("data/biome/_biomes_all.xml") do

--- a/files/content/milk_biome/materials.xml
+++ b/files/content/milk_biome/materials.xml
@@ -1,5 +1,5 @@
 <Materials>
-	<!-- Cheese wang colors: ffF3CD67 through ffF3CD75 -->
+	<!-- Cheese wang colors: ffF3CD67 through ffF3CD76 -->
 	<!-- ###################################### SOLIDS ###################################### -->
 
 	<!-- Yellow Cheddar -->
@@ -234,6 +234,75 @@
 			/>
 		<StatusEffects><Ingestion><StatusEffect type="NONE" amount="1"/></Ingestion></StatusEffects>
 	</CellDataChild>
+
+	<!-- ###################################### LIQUIDS ###################################### -->
+  <CellData
+		name="fairmod_egg_white"
+		ui_name="$fairmod_mat_egg_white"
+  	tags="[corrodible],[meltable_to_lava],[alchemy],[food],[egg]"
+		burnable="0"
+		density="4.95"
+		cell_type="liquid"
+		wang_color="ffF3DD11"
+		generates_smoke="0"
+		liquid_gravity="0.1"
+		liquid_sand="0"
+		liquid_sticks_to_ceiling="40"
+		liquid_slime="1"
+		liquid_stains="2"
+		stickyness="0.0"
+		solid_friction="1.0"
+		on_fire="0"
+		requires_oxygen="0"
+		temperature_of_fire="10" 
+		audio_physics_material_event="slime"
+		audio_physics_material_wall="slime"
+		audio_physics_material_solid="slime" 
+		show_in_creative_mode="1"
+		>
+		<Graphics color="66F3EEE2" />
+		<StatusEffects>
+			<Stains>
+				<StatusEffect type="SLIMY" />
+			</Stains>
+			<Ingestion><StatusEffect type="NONE" amount="1"/></Ingestion>
+		</StatusEffects>
+  </CellData>
+
+  <CellData
+		name="fairmod_egg_yolk"
+		ui_name="$fairmod_mat_egg_yolk"
+  	tags="[corrodible],[meltable_to_lava],[alchemy],[food],[egg]"
+		burnable="0"
+		density="4.96"
+		cell_type="liquid"
+		wang_color="ffF3DD12"
+		generates_smoke="0"
+		liquid_gravity="0.1"
+		liquid_sand="0"
+		liquid_sticks_to_ceiling="40"
+		liquid_slime="1"
+		liquid_stains="2"
+		stickyness="0.0"
+		solid_friction="1.0"
+		on_fire="0"
+		requires_oxygen="0"
+		temperature_of_fire="10" 
+		audio_physics_material_event="slime"
+		audio_physics_material_wall="slime"
+		audio_physics_material_solid="slime" 
+		show_in_creative_mode="1"
+		>
+		<Graphics color="EEFFD23C" />
+		<StatusEffects>
+			<Stains>
+				<StatusEffect type="SLIMY" />
+			</Stains>
+			<Ingestion><StatusEffect type="NONE" amount="1"/></Ingestion>
+		</StatusEffects>
+  </CellData>
+
+
 
 	<!-- ###################################### OVERRIDES ###################################### -->
 	<!-- Override vanilla cheese -->

--- a/files/content/more_orbs/chest_random_append.lua
+++ b/files/content/more_orbs/chest_random_append.lua
@@ -1,0 +1,27 @@
+
+local old_drop_random_reward = drop_random_reward
+function drop_random_reward(x, y, entity_id, rand_x, rand_y, set_rnd_)
+	local set_rnd = set_rnd_ or false 
+	if( set_rnd ) then
+		SetRandomSeed(GameGetFrameNum(), x + y + entity_id)
+	end
+
+	if Random(1,120) > 1 then
+		return old_drop_random_reward(x, y, entity_id, rand_x, rand_y, set_rnd)
+	end
+
+	local eid = EntityLoad("data/entities/items/orbs/orb_11.xml", x + Random(-10,10), y - 4 + Random(-5,5))
+
+	local orb_comp = EntityGetFirstComponentIncludingDisabled(eid, "OrbComponent")
+	if orb_comp ~= nil then
+		ComponentSetValue2(orb_comp, "orb_id", GameGetOrbCountThisRun() + 1)
+	end
+
+	local item_comp = EntityGetFirstComponent( eid, "ItemComponent" )
+	if item_comp ~= nil then
+		if( ComponentGetValue2( item_comp, "auto_pickup") ) then
+			ComponentSetValue2( item_comp, "next_frame_pickable", GameGetFrameNum() + 30 )	
+		end
+	end
+	return true
+end

--- a/files/content/more_orbs/init.lua
+++ b/files/content/more_orbs/init.lua
@@ -1,0 +1,12 @@
+local nxml = dofile_once("mods/noita.fairmod/files/lib/nxml.lua") --- @type nxml
+
+local chest_random_append = "mods/noita.fairmod/files/content/more_orbs/chest_random_append.lua"
+local append_to = {
+	"data/scripts/items/chest_random.lua",
+	"data/scripts/items/chest_random_super.lua",
+	"data/scripts/items/utility_box.lua",
+}
+
+for _, script in ipairs(append_to) do
+	ModLuaFileAppend(script, chest_random_append)
+end

--- a/files/content/more_orbs/init.lua
+++ b/files/content/more_orbs/init.lua
@@ -10,3 +10,10 @@ local append_to = {
 for _, script in ipairs(append_to) do
 	ModLuaFileAppend(script, chest_random_append)
 end
+
+for xml in nxml.edit_file("data/entities/items/orbs/orb_base.xml") do
+	local item_comp = xml:first_of("ItemComponent")
+	if item_comp ~= nil then
+		item_comp:set("auto_pickup", 1)
+	end
+end

--- a/files/content/no_easy_ti/event_list_append.lua
+++ b/files/content/no_easy_ti/event_list_append.lua
@@ -1,0 +1,6 @@
+-- Remove all good events
+for i = #streaming_events, 1, -1 do
+	if streaming_events[i].kind == STREAMING_EVENT_GOOD then
+		table.remove(streaming_events, i)
+	end
+end

--- a/files/content/no_easy_ti/init.lua
+++ b/files/content/no_easy_ti/init.lua
@@ -1,0 +1,2 @@
+
+ModLuaFileAppend("data/scripts/streaming_integration/event_list.lua", "mods/noita.fairmod/files/content/no_easy_ti/event_list_append.lua")

--- a/files/translations/content/milk_biome.csv
+++ b/files/translations/content/milk_biome.csv
@@ -30,3 +30,6 @@ farimod_mat_cheese_raclette,raclette,ракле́т,,raclette,raclettekäse,racl
 farimod_mat_cheese_paneer,paneer,пани́р,,queso indio,,panir,,panir,鄉村起士,パニール,파니르,,Translations from wiktionary,
 farimod_mat_cheese_pecorino,pecorino,,,pecorino,,,pecorino,,,,,,,
 farimod_mat_cheese_cream,cream cheese,сли́вочный сыр,queijo cremoso,,frischkäse,fromage en crème,,serek śmietankowy,奶油芝士,クリームチーズ,크림치즈,,Translations from wiktionary,
+fairmod_mat_egg_white,egg white,белок,clara,clara,eiweiß,blanc d’œuf,chiara,białko,蛋白,卵白,흰자위,,,
+fairmod_mat_egg_yolk,egg yolk,желто́к,gema,yema,eidotter,jaune d’œuf,tuorlo,żółtko,蛋黄,卵黄,노른자,,,
+fairmod_mat_egg_scrambled,scrambled egg,яи́чница,ovos mexidos,huevos revueltos,rührei,œufs brouillés,uova strapazzate,jajecznica,炒蛋,スクランブルエッグ,스크램블드 에그,,,

--- a/init.lua
+++ b/init.lua
@@ -102,6 +102,7 @@ dofile_once("mods/noita.fairmod/files/content/mod_compat/init.lua")
 dofile_once("mods/noita.fairmod/files/content/crackable_potions/init.lua")
 dofile_once("mods/noita.fairmod/files/content/fix_global_pickups/init.lua")
 dofile_once("mods/noita.fairmod/files/content/cheese_finish/init.lua")
+dofile_once("mods/noita.fairmod/files/content/more_orbs/init.lua")
 
 ModMaterialsFileAdd("mods/noita.fairmod/files/content/backrooms/materials.xml")
 ModMaterialsFileAdd("mods/noita.fairmod/files/content/better_world/materials.xml")

--- a/init.lua
+++ b/init.lua
@@ -103,6 +103,7 @@ dofile_once("mods/noita.fairmod/files/content/crackable_potions/init.lua")
 dofile_once("mods/noita.fairmod/files/content/fix_global_pickups/init.lua")
 dofile_once("mods/noita.fairmod/files/content/cheese_finish/init.lua")
 dofile_once("mods/noita.fairmod/files/content/more_orbs/init.lua")
+dofile_once("mods/noita.fairmod/files/content/boss_arena_improvements/init.lua")
 
 ModMaterialsFileAdd("mods/noita.fairmod/files/content/backrooms/materials.xml")
 ModMaterialsFileAdd("mods/noita.fairmod/files/content/better_world/materials.xml")

--- a/init.lua
+++ b/init.lua
@@ -101,6 +101,7 @@ dofile_once("mods/noita.fairmod/files/content/otherworld_shop/init.lua")
 dofile_once("mods/noita.fairmod/files/content/mod_compat/init.lua")
 dofile_once("mods/noita.fairmod/files/content/crackable_potions/init.lua")
 dofile_once("mods/noita.fairmod/files/content/fix_global_pickups/init.lua")
+dofile_once("mods/noita.fairmod/files/content/cheese_finish/init.lua")
 
 ModMaterialsFileAdd("mods/noita.fairmod/files/content/backrooms/materials.xml")
 ModMaterialsFileAdd("mods/noita.fairmod/files/content/better_world/materials.xml")

--- a/init.lua
+++ b/init.lua
@@ -104,6 +104,7 @@ dofile_once("mods/noita.fairmod/files/content/fix_global_pickups/init.lua")
 dofile_once("mods/noita.fairmod/files/content/cheese_finish/init.lua")
 dofile_once("mods/noita.fairmod/files/content/more_orbs/init.lua")
 dofile_once("mods/noita.fairmod/files/content/boss_arena_improvements/init.lua")
+dofile_once("mods/noita.fairmod/files/content/no_easy_ti/init.lua")
 
 ModMaterialsFileAdd("mods/noita.fairmod/files/content/backrooms/materials.xml")
 ModMaterialsFileAdd("mods/noita.fairmod/files/content/better_world/materials.xml")


### PR DESCRIPTION
- Convert the world to random cheeses if cheats are used.
- Chests can drop orbs easily.
- Orbs are now picked up when touched.
- Enemies can collect orbs.
- 33% chance of snowman troll in The Laboratory.
- All "good" streaming events are removed.
- Fix a weird spidernest error?
- Added egg whites and egg yolks, spawned from eggs.
