### PR TITLE
Fixed gold_invisible_box2d's HP and durability values

### DIFF
--- a/files/content/gold_bananas/materials.xml
+++ b/files/content/gold_bananas/materials.xml
@@ -9,6 +9,8 @@
 		audio_physics_material_wall="gravel"
 		audio_physics_material_solid="gold"
 		show_in_creative_mode="1"
+		durability="14"
+		hp="30000"
 	>
 		<Graphics
 			normal_mapped="0"


### PR DESCRIPTION
Because gold_invisible_box2d defaulted to 100 hp and 0 durability instead of its [original value](https://noita.wiki.gg/wiki/Gold)

It bugged me when I made it a standalone mod. Feel free to merge it (or not)
Though the idea of gold being this fragile as a feature is really funny